### PR TITLE
Drop support for LTS-14 and LTS-15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,8 +128,8 @@ workflows:
       - build-test-linux:
           matrix:
               parameters:
-                resolver: ["lts-14.1", "lts-16.31", "lts-18.27", "lts-19.13"]
+                resolver: ["lts-16.31", "lts-18.28", "lts-19.33", "lts-20.11"]
       - build-test-osx:
           matrix:
               parameters:
-                resolver: ["lts-14.1", "lts-16.31", "lts-18.27", "lts-19.13"]
+                resolver: ["lts-16.31", "lts-18.28", "lts-19.33", "lts-20.11"]

--- a/launchdarkly-server-sdk-redis-hedis.cabal
+++ b/launchdarkly-server-sdk-redis-hedis.cabal
@@ -43,14 +43,14 @@ library
       TypeApplications
   ghc-options: -fwarn-unused-imports -Wall -Wno-name-shadowing
   build-depends:
-      aeson >=1.4.4.0 && <1.6 || >=2.0.1.0 && <2.2
-    , base >=4.7 && <5
-    , bytestring >=0.10.8.2 && <0.12
-    , exceptions >=0.10.2 && <0.11
-    , generic-lens >=1.1.0.0 && <2.3
-    , hedis >=0.12.7 && <0.16
+      aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.2
+    , base >=4.13.0.0 && <5
+    , bytestring >=0.10.10.1 && <0.12
+    , exceptions >=0.10.4 && <0.11
+    , generic-lens >=2.0.0.0 && <2.3
+    , hedis >=0.12.15 && <0.16
     , launchdarkly-server-sdk
-    , text >=1.2.3.1 && <2.1
+    , text >=1.2.4.0 && <2.1
   default-language: Haskell2010
 
 test-suite haskell-server-sdk-redis-hedis-test
@@ -77,12 +77,12 @@ test-suite haskell-server-sdk-redis-hedis-test
   ghc-options: -rtsopts -threaded -with-rtsopts=-N -Wno-name-shadowing -fwarn-unused-imports -Wall
   build-depends:
       HUnit
-    , aeson >=1.4.4.0 && <1.6 || >=2.0.1.0 && <2.2
-    , base >=4.7 && <5
-    , bytestring >=0.10.8.2 && <0.12
-    , exceptions >=0.10.2 && <0.11
-    , generic-lens >=1.1.0.0 && <2.3
-    , hedis >=0.12.7 && <0.16
+    , aeson >=1.4.7.1 && <1.6 || >=2.0.1.0 && <2.2
+    , base >=4.13.0.0 && <5
+    , bytestring >=0.10.10.1 && <0.12
+    , exceptions >=0.10.4 && <0.11
+    , generic-lens >=2.0.0.0 && <2.3
+    , hedis >=0.12.15 && <0.16
     , launchdarkly-server-sdk
-    , text >=1.2.3.1 && <2.1
+    , text >=1.2.4.0 && <2.1
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -27,13 +27,13 @@ library:
   - -Wno-name-shadowing
 
 dependencies:
-  - aeson >=1.4.4.0 && <1.6 || >= 2.0.1.0 && <2.2
-  - base >=4.7 && <5
-  - bytestring >=0.10.8.2 && <0.12
-  - exceptions >=0.10.2 && <0.11
-  - hedis >=0.12.7 && <0.16
-  - generic-lens >=1.1.0.0 && <2.3
-  - text >=1.2.3.1 && <2.1
+  - aeson >=1.4.7.1 && <1.6 || >= 2.0.1.0 && <2.2
+  - base >=4.13.0.0 && <5
+  - bytestring >=0.10.10.1 && <0.12
+  - exceptions >=0.10.4 && <0.11
+  - hedis >=0.12.15 && <0.16
+  - generic-lens >=2.0.0.0 && <2.3
+  - text >=1.2.4.0 && <2.1
   - launchdarkly-server-sdk
 tests:
   haskell-server-sdk-redis-hedis-test:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-14.1
+resolver: lts-16.31
 
 packages:
 - .
 
 extra-deps:
 - git: git@github.com:launchdarkly/haskell-server-sdk-private.git
-  commit: ea630edb8ac19f5a3ddf1657f426c67d3a4c458d
+  commit: 182e2e124619bb34ba5ede3edf68f1ae6813492a


### PR DESCRIPTION
We are no longer going to support the stack-lts-14 and stack-lts-15 resolvers. The new minimum is LTS-16.33, which targets the GHC v8.8.4.

Most packages only see a patch update, a few have some feature updates. generic-lens is the biggest change, jumping a full major version.

However, this will allow us to drop support for lens in the mainline SDK, as requested [in a previous pr][1].

[1]: https://github.com/launchdarkly/haskell-server-sdk/pull/34