### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/update-cabal/action.yml
+++ b/.github/actions/update-cabal/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: haskell-actions/setup@v2
+    - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2
       with:
         ghc-version: ${{ inputs.ghc-version }}
 

--- a/.github/actions/update-cabal/action.yml
+++ b/.github/actions/update-cabal/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2
+    - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2.10.3
       with:
         ghc-version: ${{ inputs.ghc-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,21 +80,21 @@ jobs:
         with:
           ghc-version: '9.4.7'
 
-      - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2
+      - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2.10.3
         with:
           ghc-version: '9.4.7'
 
       - name: 'Set up HLint'
-        uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2
+        uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2.4.10
         with:
           version: 3.5
 
       - name: 'Run HLint'
-        uses: haskell-actions/hlint-run@eaca4cfbf4a69f4eb875df38b6bc3e1657020378 # v2
+        uses: haskell-actions/hlint-run@eaca4cfbf4a69f4eb875df38b6bc3e1657020378 # v2.4.10
         with:
           fail-on: warning
 
-      - uses: haskell-actions/run-fourmolu@5a9f41fa092841e52e6c57dde5600e586fa766a4 # v10
+      - uses: haskell-actions/run-fourmolu@5a9f41fa092841e52e6c57dde5600e586fa766a4 # v10.0.0
         with:
           version: "0.10.1.0"
           pattern: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,21 +80,21 @@ jobs:
         with:
           ghc-version: '9.4.7'
 
-      - uses: haskell-actions/setup@v2
+      - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2
         with:
           ghc-version: '9.4.7'
 
       - name: 'Set up HLint'
-        uses: haskell-actions/hlint-setup@v2
+        uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2
         with:
           version: 3.5
 
       - name: 'Run HLint'
-        uses: haskell-actions/hlint-run@v2
+        uses: haskell-actions/hlint-run@eaca4cfbf4a69f4eb875df38b6bc3e1657020378 # v2
         with:
           fail-on: warning
 
-      - uses: haskell-actions/run-fourmolu@v10
+      - uses: haskell-actions/run-fourmolu@5a9f41fa092841e52e6c57dde5600e586fa766a4 # v10
         with:
           version: "0.10.1.0"
           pattern: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change, but incorrect SHAs or upstream action changes could break CI/release workflows at runtime.
> 
> **Overview**
> Pins third-party GitHub Actions to full commit SHAs across workflows to reduce supply-chain risk.
> 
> Updates `haskell-actions/setup`, `hlint-setup`, `hlint-run`, and `run-fourmolu` in `ci.yml`, pins `haskell-actions/setup` in the `update-cabal` composite action, and pins `googleapis/release-please-action` in `release-please.yml` (no functional logic changes beyond action resolution).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33dd1b20361ce76c04d2657dde010cf97e796e80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->